### PR TITLE
Fix some serving samples' Dockerfile to run as non-root user

### DIFF
--- a/code-samples/serving/cloudevents/cloudevents-dotnet/Dockerfile
+++ b/code-samples/serving/cloudevents/cloudevents-dotnet/Dockerfile
@@ -25,6 +25,21 @@ RUN dotnet publish -c Release -o out
 
 # Build runtime image
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-alpine
-WORKDIR /app
+
+ARG USER=knative
+ARG USER_UID=1001
+ARG USER_GID=$USER_UID
+
+# Create and change to the app directory.
+WORKDIR "/home/${USER}/app"
+
+# Creates a non-root user to be used exclusively to run the application.
+RUN addgroup -g $USER_GID -S $USER && \
+    adduser -u $USER_UID -G $USER -h "/home/${USER}" -D $USER
+
 COPY --from=build-env /app/out .
+
+# Set the non-root user as current.
+USER $USER
+
 ENTRYPOINT ["dotnet", "CloudEventsSample.dll"]

--- a/code-samples/serving/cloudevents/cloudevents-go/Dockerfile
+++ b/code-samples/serving/cloudevents/cloudevents-go/Dockerfile
@@ -25,10 +25,25 @@ RUN go mod download
 # https://hub.docker.com/_/alpine
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3
-RUN apk add --no-cache ca-certificates
+
+ARG USER=knative
+ARG USER_UID=1001
+ARG USER_GID=$USER_UID
+
+# Create and change to the app directory.
+WORKDIR "/home/${USER}/app"
+
+# Creates a non-root user to be used exclusively to run the application.
+# Enable the use of outbound https.
+RUN addgroup -g $USER_GID -S $USER && \
+    adduser -u $USER_UID -G $USER -h "/home/${USER}" -D $USER && \
+    apk add --no-cache ca-certificates
 
 # Copy the binary to the production image from the builder stage.
-COPY --from=builder /app/server /server
+COPY --from=builder /app/server ./server
+
+# Set the non-root user as current.
+USER $USER
 
 # Run the web service on container startup.
-CMD ["/server"]
+CMD ["./server"]

--- a/code-samples/serving/cloudevents/cloudevents-go/README.md
+++ b/code-samples/serving/cloudevents/cloudevents-go/README.md
@@ -31,7 +31,7 @@ cd knative-docs/code-samples/serving/cloudevents/cloudevents-go
 - [Docker](https://www.docker.com) installed and running on your local machine,
   and a Docker Hub account configured (we'll use it for a container registry).
 
-## The sample code.
+## The sample code
 
 1. If you look in `cloudevents.go`, you will see two key functions for the different modes of operation:
 
@@ -49,45 +49,55 @@ cd knative-docs/code-samples/serving/cloudevents/cloudevents-go
 
 2. Choose how you would like to build the application:
 
- ### Dockerfile
+### Dockerfile
 
- * If you look in `Dockerfile`, you will see a method for pulling in the dependencies and building a small Go container based on Alpine. You can build and push this to your registry of choice via:
+- If you look in `Dockerfile`, you will see a method for pulling in the dependencies and building a small Go container based on Alpine. You can build and push this to your registry of choice via:
+
 ```bash
 # Build and push the container on your local machine.
 docker buildx build --platform linux/arm64,linux/amd64 -t "<image>" --push .
 ```
 
- ### ko
+### ko
 
- * You can use [`ko`](https://github.com/google/ko) to build and push just the image with:
+- You can use [`ko`](https://github.com/google/ko) to build and push just the image with:
+
 ```bash
 ko publish github.com/knative/docs/code-samples/serving/cloudevents/cloudevents-go
 ```
- However, if you use `ko` for the next step, this is not necessary.
 
+However, if you use `ko` for the next step, this is not necessary.
 
 3. Choose how you would like to deploy the application:
 
- ### yaml (with Dockerfile)
- * If you look in `service.yaml`, take the `<image>` name you used earlier and insert it into the `image:` field, then run:
+### yaml (with Dockerfile)
+
+- If you look in `service.yaml`, take the `<image>` name you used earlier and insert it into the `image:` field, then run:
+
 ```bash
 kubectl apply -f service.yaml
 ```
 
- ### yaml (with ko)
- * If using `ko` to build and push:
+### yaml (with ko)
+
+- If using `ko` to build and push:
+
 ```bash
 ko apply -f service.yaml
 ```
 
- ### kn (with Dockerfile)
- * If using `kn` to deploy:
+### kn (with Dockerfile)
+
+- If using `kn` to deploy:
+
 ```bash
 kn service create cloudevents-go --image=<IMAGE>
 ```
 
- ### kn (with ko)
- * You can compose `kn` and `ko` to build and deploy with a single step using:
+### kn (with ko)
+
+- You can compose `kn` and `ko` to build and deploy with a single step using:
+
 ```bash
 kn service create cloudevents-go --image=$(ko publish github.com/knative/docs/code-samples/serving/cloudevents/cloudevents-go)
 ```

--- a/code-samples/serving/cloudevents/cloudevents-nodejs/Dockerfile
+++ b/code-samples/serving/cloudevents/cloudevents-nodejs/Dockerfile
@@ -12,7 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi8/nodejs-12
+FROM node:12-slim
+
+ARG USER=knative
+ARG USER_UID=1001
+ARG USER_GID=$USER_UID
+ARG ENV=production
+
+# Doc port listening port
+ENV PORT 8080
+# Set current node env
+ENV NODE_ENV $ENV
+
+# Create and change to the app directory.
+WORKDIR "/home/${USER}/app"
 
 # Copy application dependency manifests to the container image.
 # A wildcard is used to ensure both package.json AND package-lock.json are copied.
@@ -20,19 +33,17 @@ FROM registry.access.redhat.com/ubi8/nodejs-12
 COPY package*.json ./
 
 # Use ci is faster and more reliable following package-lock.json
-RUN npm ci --only=production
-
-# Doc port listening port
-ENV PORT 8080
-
-EXPOSE $PORT
-
-ARG ENV=production
-
-ENV NODE_ENV $ENV
-
-# Run the web service on container startup.
-CMD npm run $NODE_ENV
+RUN groupadd -g $USER_GID $USER && \
+    useradd -u $USER_UID -g $USER_GID -m $USER && \
+    npm ci --only=production
 
 # Copy local code to the container image.
 COPY . ./
+
+EXPOSE $PORT
+
+# Set the non-root user as current.
+USER $USER
+
+# Run the web service on container startup.
+CMD npm run $NODE_ENV

--- a/code-samples/serving/gitwebhook-go/Dockerfile
+++ b/code-samples/serving/gitwebhook-go/Dockerfile
@@ -32,7 +32,24 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /go/bin/webh
 
 FROM golang:alpine
 
-EXPOSE 8080
-COPY --from=builder /go/bin/webhook-sample /app/webhook-sample
+ARG USER=knative
+ARG USER_UID=1001
+ARG USER_GID=$USER_UID
 
-ENTRYPOINT ["/app/webhook-sample"]
+ENV PORT=8080
+
+# Create and change to the app directory.
+WORKDIR "/home/${USER}/app"
+
+# Creates a non-root user to be used exclusively to run the application.
+RUN addgroup -g $USER_GID -S $USER && \
+    adduser -u $USER_UID -G $USER -h "/home/${USER}" -D $USER
+
+COPY --from=builder /go/bin/webhook-sample ./webhook-sample
+
+EXPOSE $PORT
+
+# Set the non-root user as current.
+USER $USER
+
+ENTRYPOINT ["./webhook-sample"]

--- a/code-samples/serving/hello-world/helloworld-csharp/Dockerfile
+++ b/code-samples/serving/hello-world/helloworld-csharp/Dockerfile
@@ -12,8 +12,22 @@ RUN dotnet publish -c Release -o out
 
 # Build runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:6.0
-WORKDIR /app
+
+ARG USER=knative
+ARG USER_UID=1001
+ARG USER_GID=$USER_UID
+
+# Create and change to the app directory.
+WORKDIR "/home/${USER}/app"
+
+# Creates a non-root user to be used exclusively to run the application.
+RUN groupadd -g $USER_GID $USER && \
+    useradd -u $USER_UID -g $USER_GID -m $USER
+
 COPY --from=build-env /app/out .
+
+# Set the non-root user as current.
+USER $USER
 
 # Run the web service on container startup.
 ENTRYPOINT ["dotnet", "helloworld-csharp.dll"]

--- a/code-samples/serving/hello-world/helloworld-go/Dockerfile
+++ b/code-samples/serving/hello-world/helloworld-go/Dockerfile
@@ -24,10 +24,25 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -mod=readonly -
 # https://hub.docker.com/_/alpine
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3
-RUN apk add --no-cache ca-certificates
+
+ARG USER=knative
+ARG USER_UID=1001
+ARG USER_GID=$USER_UID
+
+# Create and change to the app directory.
+WORKDIR "/home/${USER}/app"
+
+# Creates a non-root user to be used exclusively to run the application.
+# Enable the use of outbound https.
+RUN addgroup -g $USER_GID -S $USER && \
+    adduser -u $USER_UID -G $USER -h "/home/${USER}" -D $USER && \
+    apk add --no-cache ca-certificates
 
 # Copy the binary to the production image from the builder stage.
-COPY --from=builder /app/server /server
+COPY --from=builder /app/server ./server
+
+# Set the non-root user as current.
+USER $USER
 
 # Run the web service on container startup.
-CMD ["/server"]
+CMD ["./server"]

--- a/code-samples/serving/hello-world/helloworld-go/README.md
+++ b/code-samples/serving/hello-world/helloworld-go/README.md
@@ -59,10 +59,9 @@ git clone https://github.com/knative/docs.git knative-docs
 cd knative-docs/code-samples/serving/hello-world/helloworld-go
 ```
 
-
 Navigate to your project directory and copy the following code into a new file named `Dockerfile`:
 
-```dockerfile
+```Dockerfile
 # Use the official Golang image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 FROM golang:latest as builder
@@ -89,13 +88,28 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -mod=readonly -
 # https://hub.docker.com/_/alpine
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3
-RUN apk add --no-cache ca-certificates
+
+ARG USER=knative
+ARG USER_UID=1001
+ARG USER_GID=$USER_UID
+
+# Create and change to the app directory.
+WORKDIR "/home/${USER}/app"
+
+# Creates a non-root user to be used exclusively to run the application.
+# Install ca-certificates.
+RUN addgroup -g $USER_GID -S $USER && \
+    adduser -u $USER_UID -G $USER -h "/home/${USER}" -D $USER && \
+    apk add --no-cache ca-certificates
 
 # Copy the binary to the production image from the builder stage.
-COPY --from=builder /app/server /server
+COPY --from=builder /app/server ./server
+
+# Set the non-root user as current.
+USER $USER
 
 # Run the web service on container startup.
-CMD ["/server"]
+CMD ["./server"]
 ```
 
 Use the Go tool to create a [`go.mod`](https://github.com/golang/go/wiki/Modules#gomod) manifest.
@@ -116,6 +130,7 @@ docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld
 ```
 
 ### Deploying to knative
+
 After the build has completed and the container is pushed to docker hub, you can deploy the app into your cluster. Choose one of the following methods:
 
 ### yaml
@@ -145,22 +160,25 @@ After the build has completed and the container is pushed to docker hub, you can
  ```bash
  kubectl apply --filename service.yaml
  ```
+
 After your service is created, Knative will perform the following steps:
+
  - Create a new immutable revision for this version of the app.
  - Network programming to create a route, ingress, service, and load  balance for your app.
  - Automatically scale your pods up and down (including to zero active pods).
 
 1. Run the following command to find the domain URL for your service:
+
  ```bash
  kubectl get ksvc helloworld-go  --output=custom-columns=NAME:.metadata.name,URL:.status.url
  ```
 
  Example:
+
  ```bash
  NAME                URL
  helloworld-go       http://helloworld-go.default.1.2.3.4.xip.io
  ```
-
 
 ### kn
 
@@ -171,6 +189,7 @@ After your service is created, Knative will perform the following steps:
  ```
 
  You should see output like this:
+
   ```bash
   Creating service 'helloworld-go' in namespace 'default':
   0.031s The Configuration is still working to reflect the latest desired specification.
@@ -186,8 +205,6 @@ After your service is created, Knative will perform the following steps:
   ```
 
 1. You can then access your service through the resulting URL.
-
-
 
 ## Verification
 
@@ -205,11 +222,13 @@ Hello Go Sample v1!
 To remove the sample app from your cluster, delete the service record:
 
 ### kubectl
+
 ```bash
 kubectl delete --filename service.yaml
 ```
 
 ### kn
+
 ```bash
 kn service delete helloworld-go
 ```

--- a/code-samples/serving/hello-world/helloworld-java-spark/Dockerfile
+++ b/code-samples/serving/hello-world/helloworld-java-spark/Dockerfile
@@ -15,13 +15,26 @@ RUN mvn package -DskipTests
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM openjdk:8-jre-alpine
 
+ARG USER=knative
+ARG USER_UID=1001
+ARG USER_GID=$USER_UID
+
+ENV PORT=8080
+
+# Create and change to the app directory.
+WORKDIR "/home/${USER}/app"
+
+# Creates a non-root user to be used exclusively to run the application.
+RUN addgroup -g $USER_GID -S $USER && \
+    adduser -u $USER_UID -G $USER -h "/home/${USER}" -D $USER
+
 # Copy the jar to the production image from the builder stage.
 COPY --from=builder /app/target/helloworld-0.0.1-SNAPSHOT-jar-with-dependencies.jar helloworld.jar
 
-ENV PORT 8080
+EXPOSE $PORT
 
-EXPOSE 8080
+# Set the non-root user as current.
+USER $USER
 
 # Run the web service on container startup.
 CMD ["java","-jar","helloworld.jar"]
-

--- a/code-samples/serving/hello-world/helloworld-java-spring/Dockerfile
+++ b/code-samples/serving/hello-world/helloworld-java-spring/Dockerfile
@@ -14,8 +14,26 @@ RUN mvn package -DskipTests
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM openjdk:8-jre-alpine
 
+ARG USER=knative
+ARG USER_UID=1001
+ARG USER_GID=$USER_UID
+
+ENV PORT=8080
+
+# Create and change to the app directory.
+WORKDIR "/home/${USER}/app"
+
+# Creates a non-root user to be used exclusively to run the application.
+RUN addgroup -g $USER_GID -S $USER && \
+    adduser -u $USER_UID -G $USER -h "/home/${USER}" -D $USER
+
 # Copy the jar to the production image from the builder stage.
-COPY --from=builder /app/target/helloworld-*.jar /helloworld.jar
+COPY --from=builder /app/target/helloworld-*.jar helloworld.jar
+
+EXPOSE $PORT
+
+# Set the non-root user as current.
+USER $USER
 
 # Run the web service on container startup.
-CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/helloworld.jar"]
+CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "-jar", "helloworld.jar"]

--- a/code-samples/serving/hello-world/helloworld-java-spring/README.md
+++ b/code-samples/serving/hello-world/helloworld-java-spring/README.md
@@ -82,7 +82,7 @@ cd knative-docs/code-samples/serving/hello-world/helloworld-java-spring
 
 1. In your project directory, create a file named `Dockerfile` and copy the following code block into it:
 
-    ```docker
+    ```Dockerfile
     # Use the official maven/Java 8 image to create a build artifact: https://hub.docker.com/_/maven
     FROM maven:3.5-jdk-8-alpine as builder
 
@@ -99,13 +99,31 @@ cd knative-docs/code-samples/serving/hello-world/helloworld-java-spring
     # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
     FROM openjdk:8-jre-alpine
 
+    ENV PORT=8080
+
+    ARG USER=knative
+    ARG USER_UID=1001
+    ARG USER_GID=$USER_UID
+
+    # Create and change to the app directory.
+    WORKDIR "/home/${USER}/app"
+
+    # Creates a non-root user to be used exclusively to run the application.
+    RUN addgroup -g $USER_GID -S $USER && \
+        adduser -u $USER_UID -G $USER -h "/home/${USER}" -D $USER
+
     # Copy the jar to the production image from the builder stage.
-    COPY --from=builder /app/target/helloworld-*.jar /helloworld.jar
+    COPY --from=builder /app/target/helloworld-*.jar helloworld.jar
+
+    EXPOSE $PORT
+
+    # Set the non-root user as current.
+    USER $USER
 
     # Run the web service on container startup.
-    CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/helloworld.jar"]
-
+    CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "-jar", "helloworld.jar"]
     ```
+
    For detailed instructions on dockerizing a Spring Boot app, see [Spring Boot with Docker](https://spring.io/guides/gs/spring-boot-docker/).
 
    For additional information on multi-stage docker builds for Java see [Creating Smaller Java Image using Docker Multi-stage Build](http://blog.arungupta.me/smaller-java-image-docker-multi-stage-build/).
@@ -116,8 +134,8 @@ cd knative-docs/code-samples/serving/hello-world/helloworld-java-spring
     # Build and push the container on your local machine.
     docker buildx build --platform linux/arm64,linux/amd64 -t "{username}/helloworld-java-spring" --push .
     ```
-   Where `{username}` is your Docker Hub username.
 
+   Where `{username}` is your Docker Hub username.
 
 ## Deploying the app
 
@@ -151,6 +169,7 @@ Choose one of the following methods to deploy the app:
                 - name: TARGET
                   value: "Spring Boot Sample v1"
     ```
+
     Where `{username}` is your Docker Hub username.
 
     **Note:** Ensure that the container image value in `service.yaml` matches the container you built in the previous step.
@@ -220,11 +239,13 @@ Choose one of the following methods to deploy the app:
 To remove the sample app from your cluster, delete the service:
 
 ### kubectl
+
 ```bash
 kubectl delete -f service.yaml
 ```
 
 ### kn
+
 ```bash
 kn service delete helloworld-java-spring
 ```

--- a/code-samples/serving/hello-world/helloworld-kotlin/Dockerfile
+++ b/code-samples/serving/hello-world/helloworld-kotlin/Dockerfile
@@ -14,8 +14,22 @@ RUN gradle clean build --no-daemon
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM openjdk:8-jre-alpine
 
+ARG USER=knative
+ARG USER_UID=1001
+ARG USER_GID=$USER_UID
+
+# Create and change to the app directory.
+WORKDIR "/home/${USER}/app"
+
+# Creates a non-root user to be used exclusively to run the application.
+RUN addgroup -g $USER_GID -S $USER && \
+    adduser -u $USER_UID -G $USER -h "/home/${USER}" -D $USER
+
 # Copy the jar to the production image from the builder stage.
-COPY --from=builder /home/gradle/build/libs/gradle.jar /helloworld.jar
+COPY --from=builder /home/gradle/build/libs/gradle.jar helloworld.jar
+
+# Set the non-root user as current.
+USER $USER
 
 # Run the web service on container startup.
-CMD [ "java", "-jar", "-Djava.security.egd=file:/dev/./urandom", "/helloworld.jar" ]
+CMD [ "java", "-jar", "-Djava.security.egd=file:/dev/./urandom", "helloworld.jar" ]

--- a/code-samples/serving/hello-world/helloworld-kotlin/README.md
+++ b/code-samples/serving/hello-world/helloworld-kotlin/README.md
@@ -89,7 +89,7 @@ cd knative-docs/code-samples/serving/hello-world/helloworld-kotlin
 
 5. Create a file named `Dockerfile` and copy the following code block into it.
 
-   ```docker
+   ```Dockerfile
    # Use the official gradle image to create a build artifact.
    # https://hub.docker.com/_/gradle
    FROM gradle:6.7 as builder
@@ -106,11 +106,26 @@ cd knative-docs/code-samples/serving/hello-world/helloworld-kotlin
    # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
    FROM openjdk:8-jre-alpine
 
+   ARG USER=knative
+   ARG USER_UID=1001
+   ARG USER_GID=$USER_UID
+
+   # Create and change to the app directory.
+   WORKDIR "/home/${USER}/app"
+
+   # Creates a non-root user to be used exclusively to run the application.
+   RUN addgroup -g $USER_GID -S $USER && \
+      adduser -u $USER_UID -G $USER -h "/home/${USER}" -D $USER
+
    # Copy the jar to the production image from the builder stage.
-   COPY --from=builder /home/gradle/build/libs/gradle.jar /helloworld.jar
+   COPY --from=builder /home/gradle/build/libs/gradle.jar ./helloworld.jar
+
+   # Set the non-root user as current.
+   USER $USER
 
    # Run the web service on container startup.
-   CMD [ "java", "-jar", "-Djava.security.egd=file:/dev/./urandom", "/helloworld.jar" ]
+   CMD [ "java", "-jar", "-Djava.security.egd=file:/dev/./urandom", "helloworld.jar" ]
+
    ```
 
 6. Create a new file, `service.yaml` and copy the following service definition

--- a/code-samples/serving/hello-world/helloworld-nodejs/Dockerfile
+++ b/code-samples/serving/hello-world/helloworld-nodejs/Dockerfile
@@ -2,19 +2,29 @@
 # https://hub.docker.com/_/node
 FROM node:12-slim
 
+ARG USER=knative
+ARG USER_UID=1001
+ARG USER_GID=$USER_UID
+
 # Create and change to the app directory.
-WORKDIR /usr/src/app
+WORKDIR "/home/${USER}/app"
 
 # Copy application dependency manifests to the container image.
 # A wildcard is used to ensure both package.json AND package-lock.json are copied.
 # Copying this separately prevents re-running npm install on every code change.
 COPY package*.json ./
 
+# Creates a non-root user to be used exclusively to run the application.
 # Install production dependencies.
-RUN npm install --only=production
+RUN groupadd -g $USER_GID $USER && \
+    useradd -u $USER_UID -g $USER_GID -m $USER && \
+    npm install --only=production
 
 # Copy local code to the container image.
 COPY . ./
+
+# Set the non-root user as current.
+USER $USER
 
 # Run the web service on container startup.
 CMD [ "npm", "start" ]

--- a/code-samples/serving/hello-world/helloworld-python/Dockerfile
+++ b/code-samples/serving/hello-world/helloworld-python/Dockerfile
@@ -2,16 +2,28 @@
 # https://hub.docker.com/_/python
 FROM python:3.7-slim
 
-# Allow statements and log messages to immediately appear in the Knative logs
-ENV PYTHONUNBUFFERED True
+ARG USER=knative
+ARG USER_UID=1001
+ARG USER_GID=$USER_UID
 
+ENV PORT=8080
+# Allow statements and log messages to immediately appear in the Knative logs
+ENV PYTHONUNBUFFERED=True
 # Copy local code to the container image.
-ENV APP_HOME /app
-WORKDIR $APP_HOME
+ENV APP_HOME=app
+
+# Create and change to the app directory.
+WORKDIR "/home/${USER}/${APP_HOME}"
+
 COPY . ./
 
 # Install production dependencies.
-RUN pip install Flask gunicorn
+RUN groupadd -g $USER_GID $USER && \
+    useradd -u $USER_UID -g $USER_GID -m $USER && \
+    pip install Flask gunicorn
+
+# Set the non-root user as current.
+USER $USER
 
 # Run the web service on container startup. Here we use the gunicorn
 # webserver, with one worker process and 8 threads.

--- a/code-samples/serving/hello-world/helloworld-ruby/Dockerfile
+++ b/code-samples/serving/hello-world/helloworld-ruby/Dockerfile
@@ -2,14 +2,27 @@
 # https://hub.docker.com/_/ruby
 FROM ruby:2.6-slim
 
-# Install production dependencies.
-WORKDIR /usr/src/app
-COPY Gemfile Gemfile.lock ./
+ARG USER=knative
+ARG USER_UID=1001
+ARG USER_GID=$USER_UID
+
 ENV BUNDLE_FROZEN=true
-RUN gem install bundler && bundle install
+
+# Create and change to the app directory.
+WORKDIR "/home/${USER}/app"
+
+# Creates a non-root user to be used exclusively to run the application.
+# Install production dependencies.
+COPY Gemfile Gemfile.lock ./
+RUN groupadd -g $USER_GID $USER && \
+    useradd -u $USER_UID -g $USER_GID -m $USER && \
+    gem install bundler && bundle install
 
 # Copy local code to the container image.
 COPY . ./
+
+# Set the non-root user as current.
+USER $USER
 
 # Run the web service on container startup.
 CMD ["ruby", "./app.rb"]

--- a/code-samples/serving/hello-world/helloworld-ruby/README.md
+++ b/code-samples/serving/hello-world/helloworld-ruby/README.md
@@ -105,9 +105,10 @@ After the build has completed and the container is pushed to Docker Hub, you can
 
 Choose one of the following methods to deploy the app:
 
- ### yaml
+### yaml
 
- * Create a new file, `service.yaml` and copy the following service definition into the file. Make sure to replace `{username}` with your Docker Hub username.
+- Create a new file, `service.yaml` and copy the following service definition into the file. Make sure to replace `{username}` with your Docker Hub username.
+
 ```yaml
        apiVersion: serving.knative.dev/v1
        kind: Service
@@ -123,19 +124,25 @@ Choose one of the following methods to deploy the app:
                    - name: TARGET
                      value: "Ruby Sample v1"
 ```
+
 Ensure that the container image value in `service.yaml` matches the container you built in the previous step.
 Apply the configuration using `kubectl`:
+
 ```bash
 kubectl apply --filename service.yaml
 ```
 
 ### kn
- * With `kn` you can deploy the service with:
+
+- With `kn` you can deploy the service with:
+
 ```bash
 kn service create helloworld-ruby --image=docker.io/{username}/helloworld-ruby --env TARGET="Ruby Sample v1"
 ```
+
 This will wait until your service is deployed and ready, and ultimately it will print the URL through which you can access the service.
 The output will look like:
+
 ```
        Creating service 'helloworld-ruby' in namespace 'default':
 
@@ -149,7 +156,7 @@ The output will look like:
 
       Service 'helloworld-ruby' created to latest revision 'helloworld-ruby-akhft-1' is available at URL:
       http://helloworld-ruby.default.1.2.3.4.sslip.io
-    ```
+```
 
 During the creation of your service, Knative performs the following steps:
 
@@ -162,22 +169,27 @@ During the creation of your service, Knative performs the following steps:
 
 1. Run one of the followings commands to find the domain URL for your service.
 
- ### kubectl
+### kubectl
+
 ```bash
 kubectl get ksvc helloworld-ruby  --output=custom-columns=NAME:.metadata.name,URL:.status.url
 ```
 
  Example:
+
  ```bash
-NAME                URL
-helloworld-ruby     http://helloworld-ruby.default.1.2.3.4.sslip.io
+ NAME                URL
+ helloworld-ruby     http://helloworld-ruby.default.1.2.3.4.sslip.io
  ```
 
- ### kn
+### kn
+
 ```bash
 kn service describe helloworld-ruby -o url
 ```
+
 Example:
+
 ```bash
 http://helloworld-ruby.default.1.2.3.4.sslip.io
 ```
@@ -202,11 +214,13 @@ Replace the following URL with the URL returned in the previous command.
 To remove the sample app from your cluster, delete the service record:
 
 ### kubectl
+
 ```bash
 kubectl delete --filename service.yaml
 ```
 
 ### kn
+
 ```bash
 kn service delete helloworld-ruby
 ```

--- a/code-samples/serving/hello-world/helloworld-scala/Dockerfile
+++ b/code-samples/serving/hello-world/helloworld-scala/Dockerfile
@@ -15,8 +15,22 @@ RUN sbt assembly
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM openjdk:8-jre-alpine
 
+ARG USER=knative
+ARG USER_UID=1001
+ARG USER_GID=$USER_UID
+
+# Create and change to the app directory.
+WORKDIR "/home/${USER}/app"
+
+# Creates a non-root user to be used exclusively to run the application.
+RUN addgroup -g $USER_GID -S $USER && \
+    adduser -u $USER_UID -G $USER -h "/home/${USER}" -D $USER
+
 # Copy the jar to the production image from the builder stage.
-COPY --from=builder /app/target/scala-2.13/helloworld-*.jar /helloworld.jar
+COPY --from=builder /app/target/scala-2.13/helloworld-*.jar helloworld.jar
+
+# Set the non-root user as current.
+USER $USER
 
 # Run the web service on container startup.
-CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/helloworld.jar"]
+CMD ["java", "-Djava.security.egd=file:/dev/./urandom", "-jar", "helloworld.jar"]

--- a/code-samples/serving/hello-world/helloworld-scala/README.md
+++ b/code-samples/serving/hello-world/helloworld-scala/README.md
@@ -101,7 +101,6 @@ local Docker Repository.
 
 ## Deploying to Knative Serving
 
-
 ### yaml
 
 Apply the [Service yaml definition](service.yaml):
@@ -115,7 +114,7 @@ kubectl apply -f service.yaml
 With `kn` you can deploy the service with
 
  ```bash
-kn service create helloworld-scala --image=docker.io/{username}/helloworld-scala --env TARGET="Scala Sample v1"
+ kn service create helloworld-scala --image=docker.io/{username}/helloworld-scala --env TARGET="Scala Sample v1"
  ```
 
  This will wait until your service is deployed and ready, and ultimately it will print the URL through which you can access the service.
@@ -134,28 +133,30 @@ kn service create helloworld-scala --image=docker.io/{username}/helloworld-scala
 
  Service 'helloworld-scala' created to latest revision 'helloworld-scala-abcd-1' is available at URL:
  http://helloworld-scala.default.1.2.3.4.sslip.io
-```
+ ```
 
 ### kubectl
 
  1. Find the service host:
+
  ```bash
-kubectl get ksvc helloworld-scala \
---output=custom-columns=NAME:.metadata.name,URL:.status.url
-# It will print something like this, the URL is what you're looking for.
-# NAME                URL
-# helloworld-scala    http://helloworld-scala.default.1.2.3.4.sslip.io
+ kubectl get ksvc helloworld-scala \
+ --output=custom-columns=NAME:.metadata.name,URL:.status.url
+ # It will print something like this, the URL is what you're looking for.
+ # NAME                URL
+ # helloworld-scala    http://helloworld-scala.default.1.2.3.4.sslip.io
  ```
 
 2. Finally, to try your service, use the obtained URL:
 
  ```bash
-curl -v http://helloworld-scala.default.1.2.3.4.sslip.io
+ curl -v http://helloworld-scala.default.1.2.3.4.sslip.io
  ```
 
-
 ### kn
+
  1. Find the service host:
+
 ```bash
 kn service describe helloworld-scala -o url
 ```

--- a/code-samples/serving/hello-world/helloworld-shell/README.md
+++ b/code-samples/serving/hello-world/helloworld-shell/README.md
@@ -82,7 +82,9 @@ After the build has completed and the container is pushed to Docker Hub, you can
 Choose one of the following methods to deploy the app:
 
 ### yaml
+
 1. Create a new file, `service.yaml` and copy the following service definition into the file. Make sure to replace `{username}` with your Docker Hub username.
+
 ```yaml
 apiVersion: serving.knative.dev/v1
 kind: Service
@@ -98,17 +100,23 @@ spec:
             - name: TARGET
               value: "Shell Sample v1"
 ```
+
 Ensure that the container image value in `service.yaml` matches the container you built in the previous step.
+
 1. Apply the configuration using `kubectl`:
+
 ```bash
 kubectl apply --filename service.yaml
 ```
 
 ### kn
+
 1. With `kn` you can deploy the service with
+
 ```bash
 kn service create helloworld-shell --image=docker.io/{username}/helloworld-shell --env TARGET="Shell Sample v1"
 ```
+
 This will wait until your service is deployed and ready, and ultimately it will print the URL through which you can access the service.
 The output will look like:
 
@@ -137,21 +145,27 @@ During the creation of your service, Knative performs the following steps:
 
 1. Run one of the followings commands to find the domain URL for your service:
 
- ### kubectl
+### kubectl
+
 ```bash
 kubectl get ksvc helloworld-shell  --output=custom-columns=NAME:.metadata.name,URL:.status.url
 ```
+
 Example:
+
 ```bash
 NAME                URL
 helloworld-shell    http://helloworld-shell.default.1.2.3.4.sslip.io
 ```
 
- ### kn
+### kn
+
 ```bash
 kn service describe helloworld-shell -o url
 ```
+
 Example:
+
 ```bash
 http://helloworld-shell.default.1.2.3.4.sslip.io
 ```

--- a/code-samples/serving/multi-container/servingcontainer/Dockerfile
+++ b/code-samples/serving/multi-container/servingcontainer/Dockerfile
@@ -25,10 +25,25 @@ RUN CGO_ENABLED=0 GOOS=linux GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -mod
 # https://hub.docker.com/_/alpine
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3
-RUN apk add --no-cache ca-certificates
+
+ARG USER=knative
+ARG USER_UID=1001
+ARG USER_GID=$USER_UID
+
+# Create and change to the app directory.
+WORKDIR "/home/${USER}/app"
+
+# Creates a non-root user to be used exclusively to run the application.
+# Install ca-certificates.
+RUN addgroup -g $USER_GID -S $USER && \
+    adduser -u $USER_UID -G $USER -h "/home/${USER}" -D $USER && \
+    apk add --no-cache ca-certificates
 
 # Copy the binary to the production image from the builder stage.
-COPY --from=builder /app/servingcontainer /servingcontainer
+COPY --from=builder /app/servingcontainer ./servingcontainer
+
+# Set the non-root user as current.
+USER $USER
 
 # Run the web service on container startup.
-CMD ["/servingcontainer"]
+CMD ["./servingcontainer"]

--- a/code-samples/serving/multi-container/sidecarcontainer/Dockerfile
+++ b/code-samples/serving/multi-container/sidecarcontainer/Dockerfile
@@ -25,10 +25,25 @@ RUN CGO_ENABLED=0 GOOS=linux GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -mod
 # https://hub.docker.com/_/alpine
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3
-RUN apk add --no-cache ca-certificates
+
+ARG USER=knative
+ARG USER_UID=1001
+ARG USER_GID=$USER_UID
+
+# Create and change to the app directory.
+WORKDIR "/home/${USER}/app"
+
+# Creates a non-root user to be used exclusively to run the application.
+# Install ca-certificates.
+RUN addgroup -g $USER_GID -S $USER && \
+    adduser -u $USER_UID -G $USER -h "/home/${USER}" -D $USER && \
+    apk add --no-cache ca-certificates
 
 # Copy the binary to the production image from the builder stage.
-COPY --from=builder /app/sidecarcontainer /sidecarcontainer
+COPY --from=builder /app/sidecarcontainer ./sidecarcontainer
+
+# Set the non-root user as current.
+USER $USER
 
 # Run the web service on container startup.
-CMD ["/sidecarcontainer"]
+CMD ["./sidecarcontainer"]

--- a/code-samples/serving/secrets-go/Dockerfile
+++ b/code-samples/serving/secrets-go/Dockerfile
@@ -17,11 +17,24 @@ RUN CGO_ENABLED=0 GOOS=linux GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -v -
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine
 
-# Enable the use of outbound https
-RUN apk add --no-cache ca-certificates
+ARG USER=knative
+ARG USER_UID=1001
+ARG USER_GID=$USER_UID
+
+# Create and change to the app directory.
+WORKDIR "/home/${USER}/app"
+
+# Creates a non-root user to be used exclusively to run the application.
+# Enable the use of outbound https.
+RUN addgroup -g $USER_GID -S $USER && \
+    adduser -u $USER_UID -G $USER -h "/home/${USER}" -D $USER && \
+    apk add --no-cache ca-certificates
 
 # Copy the binary to the production image from the builder stage.
-COPY --from=builder /go/src/github.com/knative/docs/hellosecrets/hellosecrets /hellosecrets
+COPY --from=builder /go/src/github.com/knative/docs/hellosecrets/hellosecrets ./hellosecrets
+
+# Set the non-root user as current.
+USER $USER
 
 # Run the web service on container startup.
-CMD ["/hellosecrets"]
+CMD ["./hellosecrets"]

--- a/code-samples/serving/secrets-go/README.md
+++ b/code-samples/serving/secrets-go/README.md
@@ -89,7 +89,7 @@ cd knative-docs/code-samples/serving/secrets-go
    block into it. For detailed instructions on dockerizing a Go app, see
    [Deploying Go servers with Docker](https://blog.golang.org/docker).
 
-   ```docker
+   ```Dockerfile
    # Use the official Golang image to create a build artifact.
    # This is based on Debian and sets the GOPATH to /go.
    # https://hub.docker.com/_/golang
@@ -108,19 +108,27 @@ cd knative-docs/code-samples/serving/secrets-go
    # Use a Docker multi-stage build to create a lean production image.
    # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
    FROM alpine
+   ARG USER=knative
+   ARG USER_UID=1001
+   ARG USER_GID=$USER_UID
 
-   # Enable the use of outbound https
-   RUN apk add --no-cache ca-certificates
+   # Create and change to the app directory.
+   WORKDIR "/home/${USER}/app"
+
+   # Creates a non-root user to be used exclusively to run the application.
+   # Enable the use of outbound https.
+   RUN addgroup -g $USER_GID -S $USER && \
+       adduser -u $USER_UID -G $USER -h "/home/${USER}" -D $USER && \
+       apk add --no-cache ca-certificates
 
    # Copy the binary to the production image from the builder stage.
-   COPY --from=builder /go/src/github.com/knative/docs/hellosecrets/hellosecrets /hellosecrets
+   COPY --from=builder /go/src/github.com/knative/docs/hellosecrets/hellosecrets ./hellosecrets
 
-   # Service must listen to $PORT environment variable.
-   # This default value facilitates local development.
-   ENV PORT 8080
+   # Set the non-root user as current.
+   USER $USER
 
    # Run the web service on container startup.
-   CMD ["/hellosecrets"]
+   CMD ["./hellosecrets"]
    ```
 
 1. [Create a new Google Service Account](https://cloud.google.com/iam/docs/creating-managing-service-accounts).


### PR DESCRIPTION
Some fixes related to knative/serving#14566

## Proposed Changes

Defined a new user in the Dockerfile of the following serving sample projects to run the containers as a non-root user:

- [ ] cloudevents
  - [x] cloudevents-dotnet
  - [x] cloudevents-go
  - [x] cloudevents-nodejs
  - [ ] cloudevents-rust
  - [ ] cloudevents-spring
  - [ ] cloudevents-vertx
- [x] gitwebhook-go
- [ ] grpc-ping-go
- [ ] hello-world
  - [x] helloworld-csharp
  - [x] helloworld-go
  - [x] helloworld-java-spark
  - [x] helloworld-java-spring
  - [x] helloworld-kotlin
  - [x] helloworld-nodejs
  - [ ] helloworld-php
  - [x] helloworld-python
  - [x] helloworld-ruby
  - [x] helloworld-scala
  - [ ] helloworld-shell
- [ ] knative-routing-go
- [ ] kong-routing-go
- [x] multi-container
  - [x] servingcontainer
  - [x] sidecarcontainer
- [x] secrets-go

All items marked in the task list have been built and tested using only Docker (no Knative Service) and they work as expected.

I updated the README.md file of each project when necessary (ex. the Dockerfile if specified, markdown warnings, etc.).

In all Dockerfiles using the `gcr.io/distroless` repository for the last stage image, I didn't know which set of commands to use (useradd/groupadd vs adduser/addgroup).